### PR TITLE
protect against missing JSON data

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -112,6 +112,9 @@ def _default_request_handler():
 
 def _default_auth_request_handler():
     data = request.get_json()
+    if data is none:
+        raise JWTError('Bad Request', 'No JSON data received.')
+        
     username = data.get(current_app.config.get('JWT_AUTH_USERNAME_KEY'), None)
     password = data.get(current_app.config.get('JWT_AUTH_PASSWORD_KEY'), None)
     criterion = [username, password, len(data) == 2]


### PR DESCRIPTION
Raise JWTError with message "No JSON data received" when _default_auth_request_handler receives a request that did not contain a JSON payload.

Without this handling, JWT simply errors out, causing Flask not to return a response.